### PR TITLE
upgrade for laravel 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": "^7.4",
         "google/cloud-pubsub": "^1.1",
-        "illuminate/queue": "7.*",
+        "illuminate/queue": "8.*",
         "laravel/helpers": "^1.3"
     },
     "require-dev": {


### PR DESCRIPTION
Upgrade to support laravel 8

queue package is required to be higher version.